### PR TITLE
Enhancement: Make properties nullable

### DIFF
--- a/src/Client/Response/CreateGroupResponse.php
+++ b/src/Client/Response/CreateGroupResponse.php
@@ -25,7 +25,7 @@ class CreateGroupResponse extends Response
     /**
      * Obtained group key.
      */
-    private string $groupKey;
+    private ?string $groupKey = null;
 
     public function __construct(string $curlResponse)
     {
@@ -33,9 +33,9 @@ class CreateGroupResponse extends Response
     }
 
     /**
-     * @return string Obtained group key
+     * @return null|string Obtained group key or null if the request failed
      */
-    public function getGroupKey(): string
+    public function getGroupKey(): ?string
     {
         return $this->groupKey;
     }

--- a/src/Client/Response/LicenseResponse.php
+++ b/src/Client/Response/LicenseResponse.php
@@ -32,6 +32,9 @@ class LicenseResponse extends Response
         $this->processCurlResponse($curlResponse);
     }
 
+    /**
+     * @return null|int License credits or null if the request failed
+     */
     public function getCredits(): ?int
     {
         return $this->credits;

--- a/src/Client/Response/LicenseResponse.php
+++ b/src/Client/Response/LicenseResponse.php
@@ -25,14 +25,14 @@ class LicenseResponse extends Response
     /**
      * Number of license credits remaining.
      */
-    private int $credits;
+    private ?int $credits = null;
 
     public function __construct(string $curlResponse)
     {
         $this->processCurlResponse($curlResponse);
     }
 
-    public function getCredits(): int
+    public function getCredits(): ?int
     {
         return $this->credits;
     }

--- a/src/Client/Response/RetrieveGroupResponse.php
+++ b/src/Client/Response/RetrieveGroupResponse.php
@@ -40,6 +40,9 @@ class RetrieveGroupResponse extends Response
         $this->processCurlResponse($curlResponse);
     }
 
+    /**
+     * @return null|string Group name or null if the request failed
+     */
     public function getName(): ?string
     {
         return $this->name;

--- a/src/Client/Response/RetrieveGroupResponse.php
+++ b/src/Client/Response/RetrieveGroupResponse.php
@@ -28,19 +28,19 @@ class RetrieveGroupResponse extends Response
     /**
      * Name of the group.
      */
-    private string $name;
+    private ?string $name = null;
 
     /**
      * @var Recipient[] Group users
      */
-    private array $users;
+    private array $users = [];
 
     public function __construct(string $curlResponse)
     {
         $this->processCurlResponse($curlResponse);
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/src/Client/Response/SubscriptionResponse.php
+++ b/src/Client/Response/SubscriptionResponse.php
@@ -32,6 +32,9 @@ class SubscriptionResponse extends Response
         $this->processCurlResponse($curlResponse);
     }
 
+    /**
+     * @return null|string Subscribed user key or null if the request failed
+     */
     public function getSubscribedUserKey(): ?string
     {
         return $this->subscribed_user_key;

--- a/src/Client/Response/SubscriptionResponse.php
+++ b/src/Client/Response/SubscriptionResponse.php
@@ -25,14 +25,14 @@ class SubscriptionResponse extends Response
     /**
      * Applications that formerly collected Pushover user keys are encouraged to migrate to subscription keys.
      */
-    private string $subscribed_user_key;
+    private ?string $subscribed_user_key = null;
 
     public function __construct(string $curlResponse)
     {
         $this->processCurlResponse($curlResponse);
     }
 
-    public function getSubscribedUserKey(): string
+    public function getSubscribedUserKey(): ?string
     {
         return $this->subscribed_user_key;
     }

--- a/src/Client/Response/UserGroupValidationResponse.php
+++ b/src/Client/Response/UserGroupValidationResponse.php
@@ -22,17 +22,17 @@ use Serhiy\Pushover\Client\Response\Base\Response;
  */
 class UserGroupValidationResponse extends Response
 {
-    private bool $isGroup;
+    private ?bool $isGroup = null;
 
     /**
      * @var array<string>
      */
-    private array $devices;
+    private array $devices = [];
 
     /**
      * @var array<string>
      */
-    private array $licenses;
+    private array $licenses = [];
 
     public function __construct(string $curlResponse)
     {
@@ -60,41 +60,20 @@ class UserGroupValidationResponse extends Response
         return $this->licenses;
     }
 
-    private function setIsGroup(bool $isGroup): void
-    {
-        $this->isGroup = $isGroup;
-    }
-
-    /**
-     * @param array<string> $devices
-     */
-    private function setDevices(array $devices): void
-    {
-        $this->devices = $devices;
-    }
-
-    /**
-     * @param array<string> $licenses
-     */
-    private function setLicenses(array $licenses): void
-    {
-        $this->licenses = $licenses;
-    }
-
     private function processCurlResponse(string $curlResponse): void
     {
         $decodedCurlResponse = $this->processInitialCurlResponse($curlResponse);
 
         if ($this->getRequestStatus() === 1) {
-            $this->setDevices($decodedCurlResponse->devices);
-            $this->setLicenses($decodedCurlResponse->licenses);
+            $this->devices = $decodedCurlResponse->devices;
+            $this->licenses = $decodedCurlResponse->licenses;
 
             if ($decodedCurlResponse->group === 1) {
-                $this->setIsGroup(true);
+                $this->isGroup = true;
             }
 
             if ($decodedCurlResponse->group === 0) {
-                $this->setIsGroup(false);
+                $this->isGroup = false;
             }
         }
     }


### PR DESCRIPTION
Otherwise, if the RequestStatus is !== 1 it would be uninitialized on request, but IMHO better would be to throw in `processInitialCurlResponse` method:
```diff
    /**
     * Processes initial curl response, common to all response objects.
     */
    protected function processInitialCurlResponse(string $curlResponse): object
    {
        $this->curlResponse = $curlResponse;

        /** @var object{status: int, request: string, errors: string[]} $decodedCurlResponse */
        $decodedCurlResponse = json_decode($curlResponse);

        $this->requestStatus = $decodedCurlResponse->status;
        $this->requestToken = $decodedCurlResponse->request;

        if ($this->getRequestStatus() === 1) {
            $this->successful = true;
            $this->requestToken = $decodedCurlResponse->request;
        } else {
            $this->errors = $decodedCurlResponse->errors;
            $this->successful = false;
+
+           // throw here....
        }

        return $decodedCurlResponse;
    }
```

technically it would be a BC break, WDYT?