### PR TITLE
Change `RequestInterface::getCurlPostFields()` return type from `?array` to `array`

### DIFF
--- a/src/Client/Curl/Curl.php
+++ b/src/Client/Curl/Curl.php
@@ -38,7 +38,7 @@ class Curl
             \CURLOPT_RETURNTRANSFER => true,
         ];
 
-        if (null !== $request->getCurlPostFields()) {
+        if ([] !== $request->getCurlPostFields()) {
             $curlOptions[\CURLOPT_POSTFIELDS] = $request->getCurlPostFields();
         }
 

--- a/src/Client/Request/Request.php
+++ b/src/Client/Request/Request.php
@@ -33,14 +33,14 @@ class Request implements RequestInterface
     public const POST = 'POST';
 
     /**
-     * @param string                     $apiUrl         Full API URL
-     * @param string                     $method         Either GET or POST
-     * @param null|array<string, string> $curlPostFields array for CURLOPT_POSTFIELDS curl argument
+     * @param string                $apiUrl         Full API URL
+     * @param string                $method         Either GET or POST
+     * @param array<string, string> $curlPostFields array for CURLOPT_POSTFIELDS curl argument
      */
     public function __construct(
         private readonly string $apiUrl,
         private readonly string $method,
-        private readonly ?array $curlPostFields = null,
+        private readonly ?array $curlPostFields = [],
     ) {
     }
 

--- a/src/Client/Request/Request.php
+++ b/src/Client/Request/Request.php
@@ -54,10 +54,7 @@ class Request implements RequestInterface
         return $this->apiUrl;
     }
 
-    /**
-     * @return null|array<string, string>
-     */
-    public function getCurlPostFields(): ?array
+    public function getCurlPostFields(): array
     {
         return $this->curlPostFields;
     }

--- a/src/Client/Request/Request.php
+++ b/src/Client/Request/Request.php
@@ -20,7 +20,7 @@ namespace Serhiy\Pushover\Client\Request;
  *
  * @final since 1.7.0, real final in 2.0
  */
-class Request implements RequestInterface
+readonly class Request implements RequestInterface
 {
     /**
      * HTTP GET method.
@@ -38,9 +38,9 @@ class Request implements RequestInterface
      * @param array<string, string> $curlPostFields array for CURLOPT_POSTFIELDS curl argument
      */
     public function __construct(
-        private readonly string $apiUrl,
-        private readonly string $method,
-        private readonly ?array $curlPostFields = [],
+        private string $apiUrl,
+        private string $method,
+        private array $curlPostFields = [],
     ) {
     }
 

--- a/src/Client/Request/RequestInterface.php
+++ b/src/Client/Request/RequestInterface.php
@@ -23,7 +23,7 @@ interface RequestInterface
     public function getApiUrl(): string;
 
     /**
-     * @return null|array<string, string>
+     * @return array<string, string>
      */
-    public function getCurlPostFields(): ?array;
+    public function getCurlPostFields(): array;
 }

--- a/tests/Client/Request/RequestTest.php
+++ b/tests/Client/Request/RequestTest.php
@@ -42,10 +42,4 @@ class RequestTest extends TestCase
     {
         $this->assertEquals('https://test.com/api', $request->getApiUrl());
     }
-
-    #[Depends('testCanBeCrated')]
-    public function testGetCurlPostFields(Request $request): void
-    {
-        $this->assertIsArray($request->getCurlPostFields());
-    }
 }


### PR DESCRIPTION
Technically a BC break, but only if you created your own `Request` class, so low chance